### PR TITLE
Set codecov-action back to v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Run tests
       run: tox -e test
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v3
       with:
         files: ./coverage.xml
         fail_ci_if_error: false


### PR DESCRIPTION
After merging #59, the [CI workflow](https://github.com/ResearchObject/runcrate/actions/runs/6262658956) failed with:

```
Error: Unable to resolve action `codecov/codecov-action@v4`, unable to find version `v4`
```

