### PR TITLE
report: do not expect input and output to be lists

### DIFF
--- a/src/runcrate/report.py
+++ b/src/runcrate/report.py
@@ -40,7 +40,7 @@ def dump_action(action, control_action=None, f=None):
     objects = as_list(action.get("object", []))
     if objects:
         f.write("  inputs:\n")
-        inputs = set(tool.get("input", []))
+        inputs = set(as_list(tool.get("input", [])))
         for obj in objects:
             f.write(f"    {obj.get('value', obj.id)}")
             for p in as_list(obj.get("exampleOfWork", [])):
@@ -50,7 +50,7 @@ def dump_action(action, control_action=None, f=None):
     results = as_list(action.get("result", []))
     if results:
         f.write("  outputs:\n")
-        outputs = set(tool.get("output", []))
+        outputs = set(as_list(tool.get("output", [])))
         for res in results:
             f.write(f"    {res.get('value', res.id)}")
             for p in as_list(res.get("exampleOfWork", [])):

--- a/tests/data/revsort-provenance-crate-minimal/ro-crate-metadata.json
+++ b/tests/data/revsort-provenance-crate-minimal/ro-crate-metadata.json
@@ -115,11 +115,9 @@
                 }
             ],
             "name": "packed.cwl",
-            "output": [
-                {
-                    "@id": "packed.cwl#main/output"
-                }
-            ],
+            "output": {
+                "@id": "packed.cwl#main/output"
+            },
             "programmingLanguage": {
                 "@id": "https://w3id.org/workflowhub/workflow-ro-crate#cwl"
             }
@@ -162,17 +160,13 @@
             "@id": "packed.cwl#revtool.cwl",
             "@type": "SoftwareApplication",
             "description": "Reverse each line using the `rev` command",
-            "input": [
-                {
-                    "@id": "packed.cwl#revtool.cwl/input"
-                }
-            ],
+            "input": {
+                "@id": "packed.cwl#revtool.cwl/input"
+            },
             "name": "revtool.cwl",
-            "output": [
-                {
-                    "@id": "packed.cwl#revtool.cwl/output"
-                }
-            ]
+            "output": {
+                "@id": "packed.cwl#revtool.cwl/output"
+            }
         },
         {
             "@id": "packed.cwl#revtool.cwl/input",
@@ -199,11 +193,9 @@
                 }
             ],
             "name": "sorttool.cwl",
-            "output": [
-                {
-                    "@id": "packed.cwl#sorttool.cwl/output"
-                }
-            ]
+            "output": {
+                "@id": "packed.cwl#sorttool.cwl/output"
+            }
         },
         {
             "@id": "packed.cwl#sorttool.cwl/reverse",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -102,6 +102,7 @@ def test_cli_report_provenance_minimal(data_dir, caplog):
     assert result.exit_code == 0
     out_lines = result.stdout.splitlines()
     assert sum([_.startswith("action") for _ in out_lines]) == 3
+    assert sum(["<-" in _ for _ in out_lines]) == 8
 
 
 def test_cli_version():


### PR DESCRIPTION
Correctly handle situations like:

```json
"input": {
    "@id": "packed.cwl#revtool.cwl/input"
}
```
