### PR TITLE
convert: add whole workflow-run context to the crate

### DIFF
--- a/src/runcrate/constants.py
+++ b/src/runcrate/constants.py
@@ -24,10 +24,3 @@ WORKFLOW_PROFILE = f"{WORKFLOW_PROFILE_BASE}/{PROFILES_VERSION}"
 PROVENANCE_PROFILE = f"{PROVENANCE_PROFILE_BASE}/{PROFILES_VERSION}"
 
 TERMS_NAMESPACE = "https://w3id.org/ro/terms/workflow-run"
-EXTRA_TERMS = {t: f"{TERMS_NAMESPACE}#{t}" for t in [
-    "ParameterConnection",
-    "connection",
-    "sourceParameter",
-    "targetParameter",
-    "sha1",
-]}

--- a/src/runcrate/convert.py
+++ b/src/runcrate/convert.py
@@ -34,7 +34,7 @@ from rocrate.model.contextentity import ContextEntity
 from rocrate.model.softwareapplication import SoftwareApplication
 from rocrate.rocrate import ROCrate
 
-from .constants import EXTRA_TERMS, PROFILES_BASE, PROFILES_VERSION
+from .constants import PROFILES_BASE, PROFILES_VERSION, TERMS_NAMESPACE
 from .utils import as_list
 
 
@@ -284,7 +284,7 @@ class ProvCrateBuilder:
 
     def build(self):
         crate = ROCrate(gen_preview=False)
-        crate.metadata.extra_terms.update(EXTRA_TERMS)
+        crate.metadata.extra_contexts.append(TERMS_NAMESPACE)
         self.add_root_metadata(crate)
         self.add_profiles(crate)
         self.add_workflow(crate)

--- a/tests/test_cwlprov_crate_builder.py
+++ b/tests/test_cwlprov_crate_builder.py
@@ -17,6 +17,7 @@ import json
 import pytest
 from rocrate.rocrate import ROCrate
 
+from runcrate.constants import TERMS_NAMESPACE
 from runcrate.convert import ProvCrateBuilder
 
 
@@ -180,16 +181,7 @@ def test_revsort(data_dir, tmpdir):
     with open(output / "ro-crate-metadata.json") as f:
         metadata = json.load(f)
     context = metadata['@context']
-    context_extensions = [_ for _ in context if isinstance(_, dict)]
-    assert len(context_extensions) == 1
-    extra_terms = context_extensions[0]
-    assert extra_terms == {
-        "ParameterConnection": "https://w3id.org/ro/terms/workflow-run#ParameterConnection",
-        "connection": "https://w3id.org/ro/terms/workflow-run#connection",
-        "sha1": "https://w3id.org/ro/terms/workflow-run#sha1",
-        "sourceParameter": "https://w3id.org/ro/terms/workflow-run#sourceParameter",
-        "targetParameter": "https://w3id.org/ro/terms/workflow-run#targetParameter"
-    }
+    assert TERMS_NAMESPACE in context
 
 
 def test_no_input(data_dir, tmpdir):


### PR DESCRIPTION
Now https://w3id.org/ro/terms/workflow-run is a valid JSON-LD context, see https://github.com/ResearchObject/ro-terms/commit/71eec1ec06e9ff725554b7f02f07e07c54449415

Generated crates now start with:

```json
{
    "@context": [
        "https://w3id.org/ro/crate/1.1/context",
        "https://w3id.org/ro/terms/workflow-run"
    ],
```